### PR TITLE
fix: skip `workspace:` versions

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -23,7 +23,7 @@
     "typecheck": "tsc --noEmit --declaration"
   },
   "dependencies": {
-    "@pedaki/api": "0.4.2-beta.6",
+    "@pedaki/api": "workspace:*",
     "@pedaki/design": "0.4.2-beta.6",
     "@t3-oss/env-nextjs": "^0.7.1",
     "@tanstack/react-query": "^4.36.1",

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -87,8 +87,8 @@ const preReleaseSuffix = (useOld, preRelease) => {
 
 const updateDependencies = (dependencies, newVersion) => {
     if (!dependencies) return;
-    for (const packageName of Object.keys(dependencies)) {
-        if (packageName.startsWith('@pedaki')) {
+    for (const [packageName, version] of Object.entries(dependencies)) {
+        if (packageName.startsWith('@pedaki') && !version.startsWith('workspace:')) {
             dependencies[packageName] = newVersion;
         }
     }


### PR DESCRIPTION
Closes #18
