### PR TITLE
fix: replace environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ coverage
 .env.local
 .env.development.local
 .env.test.local
-.env.production.loc
+.env.production.local

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ yalc.lock
 dist
 .eslintcache
 coverage
-.env.*
-!*.env.test.example
-!*.env.example
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.loc

--- a/app/.env
+++ b/app/.env
@@ -1,1 +1,0 @@
-NEXT_PUBLIC_TESTVALUE=testvalue

--- a/app/.env.production
+++ b/app/.env.production
@@ -1,3 +1,5 @@
 # File used to set environment variables for the app (see entrypoint.sh)
 
 NEXT_PUBLIC_TESTVALUE=testvaluddd
+
+SECRET_PRIVATE_VARIABLE=default_value

--- a/app/.env.production
+++ b/app/.env.production
@@ -1,0 +1,3 @@
+# File used to set environment variables for the app (see entrypoint.sh)
+
+NEXT_PUBLIC_TESTVALUE=testvaluddd

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -5,6 +5,8 @@ RUN apt-get update -y && apt-get install -y openssl ca-certificates && apt-get c
 FROM base AS builder
 WORKDIR /app
 
+RUN apt-get update -y && apt-get install -y bash && apt-get clean
+
 # Install corepack pnpm
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
@@ -36,26 +38,25 @@ RUN adduser --system --uid 1001 nextjs
 
 COPY --from=builder /app/app/public ./public
 
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED 1
+ENV SKIP_SERVER_ENV_CHECK=true
+
 RUN mkdir .next
 RUN chown nextjs:nodejs .next
 
-COPY --from=builder /app/app/.next/standalone/app ./
-COPY --from=builder /app/app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/app/.next/standalone/app ./
+COPY --from=builder --chown=nextjs:nodejs /app/app/.next/static ./.next/static
 COPY --from=builder /app/app/.next/standalone/node_modules ./node_modules
+
+COPY app/entrypoint.sh .
+COPY app/.env.production .
+RUN chmod +x ./entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]
 
 USER nextjs
 
-## Load public env vars
-ARG PORT=80
-ARG NEXT_PUBLIC_TESTVALUE
-
-ENV NEXT_TELEMETRY_DISABLED 1
-ENV PORT=$PORT
-
-ENV NODE_ENV=production
-ENV SKIP_SERVER_ENV_CHECK=true
-ENV NEXT_PUBLIC_TESTVALUE=$NEXT_PUBLIC_TESTVALUE
-
+ENV PORT=80
 EXPOSE $PORT
 
 CMD ["node", "server.js"]

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# no verbose
+set +x
+# config
+envFilename='.env.production'
+nextFolder='./.next/'
+function apply_path {
+  # read all config file
+  while read -r line; do
+    # no comment or not empty
+    if [ "${line:0:1}" == "#" ] || [ "${line}" == "" ]; then
+      continue
+    fi
+
+    # split
+    configName="$(cut -d'=' -f1 <<<"$line")"
+    configValue="$(cut -d'=' -f2 <<<"$line")"
+    # get system env
+    envValue=$(env | grep "^$configName=" | grep -oe '[^=]*$');
+
+    echo "Config: ${configName} = ${configValue}"
+
+    # if config found
+    if [ -n "$configValue" ] && [ -n "$envValue" ]; then
+      # replace all
+      echo "Replace: ${configValue} with: ${envValue}"
+      find $nextFolder \( -type d -name .git -prune \) -o -type f -print0 | xargs -0 sed -i "s#$configValue#$envValue#g"
+    else
+      echo "Not found: ${configValue}"
+    fi
+  done < $envFilename
+}
+apply_path
+echo "Starting Nextjs"
+exec "$@"

--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -4,6 +4,8 @@ import { z } from 'zod';
 export const env = createEnv({
   server: {
     NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+
+    SECRET_PRIVATE_VARIABLE: z.string().min(2),
   },
   runtimeEnv: process.env,
 });

--- a/packages/api/src/router/routers/hello.ts
+++ b/packages/api/src/router/routers/hello.ts
@@ -1,3 +1,4 @@
+import { env } from '~api/env.ts';
 import { procedure, router } from '~api/router/trpc.ts';
 import { z } from 'zod';
 
@@ -10,7 +11,7 @@ export const helloRouter = router({
     )
     .query(opts => {
       return {
-        greeting: `hello ${opts.input.text}`,
+        greeting: `${env.SECRET_PRIVATE_VARIABLE} ${opts.input.text}`,
       };
     }),
 });


### PR DESCRIPTION
Le soucis avec nextjs c'est que les variables d'environnements (process.env.xyz) sont replacés lors du build.

Donc pour l'image docker si on fait `run -e VARIABLE=abc` c'est trop tard vu qu'il ne lis pas la variable d'environnement.

Ce qui est fait ici, c'est qu'on cherche toutes les endroits qui ont été remplacés lors du build et on les remplaces par les valeurs de l'env.

https://raphaelpralat.medium.com/system-environment-variables-in-next-js-with-docker-1f0754e04cde